### PR TITLE
Use strict, not stict

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -1,4 +1,4 @@
-'use stict';
+'use strict';
 
 var gulp = require('gulp');
 var liferayThemeTasks = require('liferay-theme-tasks');


### PR DESCRIPTION
Fix a single-character typo.